### PR TITLE
Improve support for CommonJS usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,4 @@
+require('angular-animate');
+require('angular-aria');
 require('./angular-material');
 module.exports = 'ngMaterial';


### PR DESCRIPTION
As folks brought up in angular/material#1655, people using tools like Browserify will expect that `angular-animate` and `angular-aria` will be required in `index.js`. Since they are listed as dependencies, they will have already been downloaded and will be available to the module system.

You don't actually need to use the path, so the possible path variations won't be a problem. When Browserify is processing the file, it uses Node's module resolution to figure out that `require('angular-animate')` should use `path/to/angular-animate`. This is one of the advantages of Browserify and CommonJS support. It means that apps which use angular-material don't need to hardcode paths for angular-material's dependencies.