### PR TITLE
Update angular peerDependencies to support ng 1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "format": "cjs",
   "registry": "github",
   "peerDependencies": {
-    "angular": ">=1.3 <1.6",
-    "angular-animate": ">=1.3 <1.6",
-    "angular-aria": ">=1.3 <1.6"
+    "angular": ">=1.3 <1.7",
+    "angular-animate": ">=1.3 <1.7",
+    "angular-aria": ">=1.3 <1.7"
   },
   "jspm": {
     "dependencies": {


### PR DESCRIPTION
Fixes angular/material#10149. Fixes angular/material#10111. Fixes angular/material#10353.