### PR TITLE
angulat-material

### DIFF
--- a/angular-material.js
+++ b/angular-material.js
@@ -20289,7 +20289,7 @@ function SelectProvider($$interimElementProvider) {
         if (options.hasBackdrop) {
           // Override duration to immediately show invisible backdrop
           options.backdrop = $mdUtil.createBackdrop(scope, "md-select-backdrop md-click-catcher");
-          $animate.enter(options.backdrop, $document[0].body, null, {duration: 0});
+          $animate.enter(options.backdrop, options.parent, null, {duration: 0});
         }
 
         /**


### PR DESCRIPTION
Change $document[0].body to options.parent when showing backdrop from mdSelect.
Otherwise it appends "[object Object]" to the body (instead of of the backdrop )