### PR TITLE
docs: update for AngularJS 1.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,47 @@
-## [1.1.22](https://github.com/angular/material/compare/v1.1.22-rc.0...v1.1.22) (2020-04-30)
+<a name="1.1.22"></a>
+## [1.1.22](https://github.com/angular/material/compare/v1.1.21...v1.1.22) (2020-04-30)
 
 
 ### Bug Fixes
 
+* **autocomplete:** loop options list when moving past first/last option with arrow keys ([5228f23](https://github.com/angular/material/commit/5228f23b963b8d3811c916c2403469b92b2cca7e)), closes [#11766](https://github.com/angular/material/issues/11766)
+* **autocomplete:** md-not-found template is not styled properly ([ce6e2ff](https://github.com/angular/material/commit/ce6e2ff13702cd462a1b45c06753d16278270ba1)), closes [#11852](https://github.com/angular/material/issues/11852)
+* **autocomplete:** Move mouse enter and leave events to container ([5b0c9ba](https://github.com/angular/material/commit/5b0c9ba9e0e5313925f6a27390559f32028fd95b)), closes [#11776](https://github.com/angular/material/issues/11776)
+* **autocomplete:** scroll to top of the list each time dropdown open ([498c9ed](https://github.com/angular/material/commit/498c9edd26e878d53e8f1b02a86380fe1b9895b1)), closes [#10479](https://github.com/angular/material/issues/10479)
+* **contact-chips:** don't rely on debug info to get access to controller scope ([2f77095](https://github.com/angular/material/commit/2f770957f7d38d9c1386767b82bd662c07af9787)), closes [#11699](https://github.com/angular/material/issues/11699)
+* **datepicker:** md-open-on-focus fails when switching tabs with open datepicker ([7a16778](https://github.com/angular/material/commit/7a16778ecc08593463c361b33b4fe17154b8cb75))
+* **gesture:** 'drag' gestures don't clean up touch action styles on parent ([deb3dfc](https://github.com/angular/material/commit/deb3dfc11e76ea38c2ec65a2a9b4d68560d0c181)), closes [#11147](https://github.com/angular/material/issues/11147)
+* **list:** dense lists cut off descenders of letters like gjqpy ([0ab73bd](https://github.com/angular/material/commit/0ab73bd86ab3f5e564ef73663e3f70e2404b2538)), closes [#8890](https://github.com/angular/material/issues/8890)
+* **list:** isEventFromControl() works on all browsers now ([d537d25](https://github.com/angular/material/commit/d537d251d7281ed446ce5b5502a123884e1af9f4)), closes [#7937](https://github.com/angular/material/issues/7937)
+* **list:** primary action is fired twice on space/enter keydown ([920018e](https://github.com/angular/material/commit/920018efbd51ed4f164db3fa02da721d3148da43)), closes [#11756](https://github.com/angular/material/issues/11756)
+* **list:** secondary actions give aria warning if text is in a span ([90c8b8d](https://github.com/angular/material/commit/90c8b8d6f6265b3c5b71f38fa847dc5c6bb9ce04)), closes [#6152](https://github.com/angular/material/issues/6152)
+* **menu-bar:** z-index not restored on menu close ([4a4dde4](https://github.com/angular/material/commit/4a4dde489835dd1c2ef221563bb5f2fd9fc9bddf)), closes [#11235](https://github.com/angular/material/issues/11235)
+* **nav-bar:** clicked nav item not focused or selected in some cases ([4d4e0ac](https://github.com/angular/material/commit/4d4e0ac9487c9a632447fa5ecf38941934c3cf2c)), closes [#11747](https://github.com/angular/material/issues/11747)
+* **select:** overhaul screen reader support ([928c71d](https://github.com/angular/material/commit/928c71d6ee87bc03ce383bfa555f67e1d373fe13)), closes [#10748](https://github.com/angular/material/issues/10748) [#10967](https://github.com/angular/material/issues/10967)
+* **select:** sanitize user input before searching options ([#11855](https://github.com/angular/material/issues/11855)) ([0ec0cc5](https://github.com/angular/material/commit/0ec0cc5ee8aac0db6103ae4c1ee1fc30620247b2)), closes [#11854](https://github.com/angular/material/issues/11854)
+* **select:** when using trackBy, trigger ng-change only when tracked property is different ([ecd55d0](https://github.com/angular/material/commit/ecd55d0dd2d52c746e4aa907bfd3712f6c03a68a)), closes [#11108](https://github.com/angular/material/issues/11108)
 * **select:** menuController not defined edge case in focusOptionNode ([b9d8322](https://github.com/angular/material/commit/b9d832209f8b9e25b4bc5dc2654bf18421144816)), closes [#11885](https://github.com/angular/material/issues/11885)
 
+### Documentation
 
+* **vscode:** add VSCode configuration and guide ([#11879](https://github.com/angular/material/pull/11879)) ([a8954df](https://github.com/angular/material/commit/a8954dfaded6b5ae36aa35eaba3f33602f1e9da3))
+* **dialog:** clarify promise rejection behavior in descriptions ([#11889](https://github.com/angular/material/pull/11889)) ([939f6c9](https://github.com/angular/material/commit/939f6c9f8ef16326b6cd15b0164afb69ae0c72fc)), closes ([#10130](https://github.com/angular/material/issues/10130))
+* **docs, README:** remove Bower references, update GitHub and NPM icons. fix 'View Demo' button appearing for directives w/o demos ([#11888](https://github.com/angular/material/pull/11888)) ([5c75b12](https://github.com/angular/material/commit/5c75b121920243410c164df7ec33558087cccf1f))
+* **getting-started, home:** updates to landing page and getting started. add Blank StackBlitz Demo starter ([#11890](https://github.com/angular/material/pull/11890)) ([d1a9976](https://github.com/angular/material/commit/d1a9976cad047288262d904460e7be6089de8128))
+* **COMMIT_LEVELS:** update guide to better describe the process and responsibilities ([#11862](https://github.com/angular/material/pull/11862)) ([38fe956](https://github.com/angular/material/commit/38fe9560e23467cabe18a8653849238946f2afa5))
+* **BUILD:** rewrote most of the guide ([#11880](https://github.com/angular/material/pull/11880)) ([4093953](https://github.com/angular/material/commit/40939534460f175543a0261c3b232d71e2a2884b))
+
+### Contributors
+
+Thank you to the contributors who helped with the v1.1.22 release:
+
+[<img alt="Splaktar" src="https://avatars1.githubusercontent.com/u/3506071?v=4&s=117" width="117">](https://github.com/Splaktar) |[<img alt="marosoft" src="https://avatars0.githubusercontent.com/u/3945455?v=4&s=117" width="117">](https://github.com/marosoft) |[<img alt="oliversalzburg" src="https://avatars2.githubusercontent.com/u/1658949?v=4&s=117" width="117">](https://github.com/oliversalzburg) |[<img alt="andrewseguin" src="https://avatars3.githubusercontent.com/u/22898577?v=4&s=117" width="117">](https://github.com/andrewseguin) |[<img alt="free-easy" src="https://avatars2.githubusercontent.com/u/20483759?v=4&s=117" width="117">](https://github.com/free-easy) |[<img alt="nathanael-bice" src="https://avatars2.githubusercontent.com/u/6155868?v=4&s=117" width="117">](https://github.com/nathanael-bice) |
+:---: |:---: |:---: |:---: |:---: |:---: |
+[Splaktar](https://github.com/Splaktar) |[marosoft](https://github.com/marosoft) |[oliversalzburg](https://github.com/oliversalzburg) |[andrewseguin](https://github.com/andrewseguin) |[free-easy](https://github.com/free-easy) |[nathanael-bice](https://github.com/nathanael-bice) |
+
+[<img alt="psamim" src="https://avatars3.githubusercontent.com/u/1868679?v=4&s=117" width="117">](https://github.com/psamim) |[<img alt="qubiack" src="https://avatars1.githubusercontent.com/u/19862364?v=4&s=117" width="117">](https://github.com/qubiack) |
+:---: |:---: |
+[psamim](https://github.com/psamim) |[qubiack](https://github.com/qubiack) |
 
 <a name="1.1.22-rc.0"></a>
 ## [1.1.22-rc.0](https://github.com/angular/material/compare/v1.1.21...v1.1.22-rc.0) (2020-03-13)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2014-2018 Google, Inc. http://angularjs.org
+Copyright (c) 2020 Google LLC. https://angularjs.org
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-This repository is used for publishing the AngularJS Material v1.x library and localized installs
-using `npm`. The component source-code for this library is in the
+This repository publishes the AngularJS Material v1.x library and localized installs
+using `npm`. You can find the component source-code for this library in the
 [AngularJS Material repository](https://github.com/angular/material).
 
 > Please file issues and pull requests against that `angular/material` repository only. Do not file
-issues here on the deployment repository.
+issues here on the publishing repository.
 
 ## Layouts and SCSS
 
@@ -21,9 +21,9 @@ developer access and contain IE flexbox fixes; as needed.
 
 You can install this package locally either with `npm`, `jspm`, or `bower` (deprecated). 
 
-**Please note**: AngularJS Material requires **AngularJS 1.4.x** to **AngularJS 1.7.x**.
+**Please note**: AngularJS Material requires **AngularJS 1.4.x** to **AngularJS 1.8.x**.
 
-**Please note**: AngularJS Material does not support AngularJS 1.7.1. 
+**Please note**: AngularJS Material does not support AngularJS 1.7.1, which has been deprecated.
 
 ### npm
 
@@ -43,8 +43,8 @@ npm install http://github.com/angular/bower-material#master --save
 #      "angular-material": "git+ssh://git@github.com/angular/bower-material.git#master"
 
 
-# To install a v1.1.9 version 
-npm install http://github.com/angular/bower-material/tarball/v1.1.9 --save
+# To install the v1.1.22 version 
+npm install http://github.com/angular/bower-material/tarball/v1.1.22 --save
 
 # To view all installed package 
 npm list;
@@ -148,28 +148,28 @@ under `/bower_components/angular-material/`.
 ## Using the CDN
 
 With the Google CDN, you will not need to download local copies of the distribution files.
-Instead simply reference the CDN urls to easily use those remote library files. 
+Instead, simply reference the CDN urls to easily use those remote library files. 
 This is especially useful when using online tools such as CodePen, Plunker, or jsFiddle.
 
 ```html
 <head>
-    <!-- Angular Material CSS now available via Google CDN; version 1.1.9 used here -->
-    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.9/angular-material.min.css">
+    <!-- Angular Material CSS now available via Google CDN; version 1.1.22 used here -->
+    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.22/angular-material.min.css">
 </head>
 <body>
 
     <!-- Angular Material Dependencies -->
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.7.2/angular.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.7.2/angular-animate.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.7.2/angular-aria.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.7.2/angular-messages.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.0/angular.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.0/angular-animate.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.0/angular-aria.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.0/angular-messages.min.js"></script>
     
-    <!-- Angular Material Javascript now available via Google CDN; version 1.1.9 used here -->
-    <script src="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.9/angular-material.min.js"></script>
+    <!-- Angular Material Javascript now available via Google CDN; version 1.1.22 used here -->
+    <script src="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.22/angular-material.min.js"></script>
 </body>
 ```
 
-> Note that the above sample references the 1.1.9 CDN release. Your version will change 
+> Note that the above sample references the 1.1.22 CDN release. Your version will change 
 based on the latest stable release version.
 
 ## Unit Testing with Angular Material


### PR DESCRIPTION
- update for latest version of AngularJS Material
- update copyright year and company name
- fix `1.1.22` changelog entry