### PR TITLE
chore: drop support for AngularJS 1.4-1.7.0. simplify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,9 @@ developer access and contain IE flexbox fixes; as needed.
 
 ## Installing AngularJS Material
 
-You can install this package locally either with `npm`, `jspm`, or `bower` (deprecated). 
+You can install this package locally with `npm`. 
 
-**Please note**: AngularJS Material requires **AngularJS 1.4.x** to **AngularJS 1.8.x**.
-
-**Please note**: AngularJS Material does not support AngularJS 1.7.1, which has been deprecated.
-
-### npm
+**Please note**: AngularJS Material requires **AngularJS 1.7.2** to **AngularJS 1.8.x**.
 
 ```shell
 # To install latest formal release 
@@ -47,49 +43,14 @@ npm install http://github.com/angular/bower-material#master --save
 npm install http://github.com/angular/bower-material/tarball/v1.1.22 --save
 
 # To view all installed package 
-npm list;
-```
-
-### jspm
-
-```shell
-# To install latest formal release
-jspm install angular-material
-
-# To install from HEAD of master
-jspm install angular-material=github:angular/bower-material@master
-
-# To view all installed package versions
-jspm inspect
-```
-
-Now you can use `require('angular-material')` when installing with **npm** or **jspm**, or when
-using Browserify or Webpack.
-
-### bower
-
-```shell
-# To get the latest stable version, use bower from the command line.
-bower install angular-material
-
-# To get the most recent, last committed-to-master version use:
-bower install 'angular-material#master'
-
-# To save the bower settings for future use:
-bower install angular-material --save
-
-# Later, you can use easily update with:
-bower update
+npm list
 ```
 
 ## Using the AngularJS Material Library
 
-Now that you have installed the AngularJS libraries, simply include the scripts and 
+You have installed the AngularJS library, next include the scripts and 
 stylesheet in your main HTML file, in the order shown in the example below. Note that NPM 
-will install the files under `/node_modules/angular-material/` and Bower will install them 
-under `/bower_components/angular-material/`.
-
-### npm
+will install the files under `/node_modules/angular-material/`.
 
 ```html
 <!DOCTYPE html>
@@ -117,44 +78,16 @@ under `/bower_components/angular-material/`.
 </html>
 ```
 
-### bower
-
-```html
-<!DOCTYPE html>
-<html>
-<head>
-  <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no" />
-  <link rel="stylesheet" href="/bower_components/angular-material/angular-material.css">
-</head>
-  <body ng-app="YourApp">
-  <div ng-controller="YourController">
-
-  </div>
-
-  <script src="/bower_components/angular/angular.js"></script>
-  <script src="/bower_components/angular-aria/angular-aria.js"></script>
-  <script src="/bower_components/angular-animate/angular-animate.js"></script>
-  <script src="/bower_components/angular-messages/angular-messages.js"></script>
-  <script src="/bower_components/angular-material/angular-material.js"></script>
-  <script>
-    // Include app dependency on ngMaterial
-    angular.module('YourApp', ['ngMaterial', 'ngMessages'])
-      .controller("YourController", YourController);
-  </script>
-</body>
-</html>
-```
-
 ## Using the CDN
 
 With the Google CDN, you will not need to download local copies of the distribution files.
-Instead, simply reference the CDN urls to easily use those remote library files. 
+Instead, reference the CDN URLs to use those remote library files. 
 This is especially useful when using online tools such as CodePen, Plunker, or jsFiddle.
 
 ```html
 <head>
-    <!-- Angular Material CSS now available via Google CDN; version 1.1.22 used here -->
-    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.22/angular-material.min.css">
+    <!-- Angular Material CSS now available via Google CDN; version 1.1.24 used here -->
+    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.24/angular-material.min.css">
 </head>
 <body>
 
@@ -164,29 +97,29 @@ This is especially useful when using online tools such as CodePen, Plunker, or j
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.0/angular-aria.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.0/angular-messages.min.js"></script>
     
-    <!-- Angular Material Javascript now available via Google CDN; version 1.1.22 used here -->
-    <script src="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.22/angular-material.min.js"></script>
+    <!-- Angular Material Javascript now available via Google CDN; version 1.1.24 used here -->
+    <script src="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.24/angular-material.min.js"></script>
 </body>
 ```
 
-> Note that the above sample references the 1.1.22 CDN release. Your version will change 
+> Note that the above sample references the 1.1.24 CDN release. Your version will change 
 based on the latest stable release version.
 
 ## Unit Testing with Angular Material
 
 <br/>
-If you are using Angular Material and will be using Jasmine to test your own custom application
-code, you will need to also load two (2) Angular mock files:
+If you are using AngularJS Material and will be using Jasmine to test your custom application
+code, you will need to also load two (2) AngularJS mock files:
 
-*  Angular Mocks
+*  AngularJS mocks
     * **angular-mocks.js** from `/node_modules/angular-mocks/angular-mocks.js`
-*  Angular Material Mocks
+*  AngularJS Material mocks
     * **angular-material-mocks.js** from `/node_modules/angular-material/angular-material-mocks.js`
 
 <br/>
 
 Shown below is a karma-configuration file (`karma.conf.js`) sample that may be a useful template for
-your own testing purposes:<br/><br/>
+your testing purposes:<br/><br/>
 
 ```js
 module.exports = function(config) {

--- a/bower.json
+++ b/bower.json
@@ -4,10 +4,10 @@
   "license": "MIT",
   "ignore": [],
   "dependencies": {
-    "angular": "1.4 - 1.7.0 || ^1.7.2",
-    "angular-animate": "1.4 - 1.7.0 || ^1.7.2",
-    "angular-aria": "1.4 - 1.7.0 || ^1.7.2",
-    "angular-messages": "1.4 - 1.7.0 || ^1.7.2"
+    "angular": "^1.7.2",
+    "angular-animate": "^1.7.2",
+    "angular-aria": "^1.7.2",
+    "angular-messages": "^1.7.2"
   },
   "main": [
     "angular-material.js",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "format": "cjs",
   "registry": "github",
   "peerDependencies": {
-    "angular": "1.4 - 1.7.0 || ^1.7.2",
-    "angular-animate": "1.4 - 1.7.0 || ^1.7.2",
-    "angular-aria": "1.4 - 1.7.0 || ^1.7.2",
-    "angular-messages": "1.4 - 1.7.0 || ^1.7.2"
+    "angular": "^1.7.2",
+    "angular-animate": "^1.7.2",
+    "angular-aria": "^1.7.2",
+    "angular-messages": "^1.7.2"
   },
   "jspm": {
     "dependencies": {


### PR DESCRIPTION
- update for latest version of AngularJS Material
- remove bower/jspm docs
- fix a few references to Angular

Fixes https://github.com/angular/material/issues/11931